### PR TITLE
Reduce number of processes running in dev

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -9,7 +9,11 @@ import Config
 config :hello_phoenix, HelloPhoenixWeb.Endpoint,
   # Binding to loopback ipv4 address prevents access from other machines.
   # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
-  http: [ip: {127, 0, 0, 1}, port: 4000],
+  http: [
+    ip: {127, 0, 0, 1},
+    port: 4000,
+    transport_options: [num_acceptors: 2]
+  ],
   check_origin: false,
   code_reloader: true,
   debug_errors: true,

--- a/lib/hello_phoenix_web/endpoint.ex
+++ b/lib/hello_phoenix_web/endpoint.ex
@@ -10,7 +10,9 @@ defmodule HelloPhoenixWeb.Endpoint do
     signing_salt: "Ihu4hNuH"
   ]
 
-  socket "/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]]
+  socket "/live", Phoenix.LiveView.Socket,
+    websocket: [connect_info: [session: @session_options]],
+    partitions: 2
 
   # Serve at "/" the static files from "priv/static" directory.
   #
@@ -25,7 +27,7 @@ defmodule HelloPhoenixWeb.Endpoint do
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.
   if code_reloading? do
-    socket "/phoenix/live_reload/socket", Phoenix.LiveReloader.Socket
+    socket "/phoenix/live_reload/socket", Phoenix.LiveReloader.Socket, partitions: 2
     plug Phoenix.LiveReloader
     plug Phoenix.CodeReloader
   end


### PR DESCRIPTION
On a 12-core machine this is what the process tree looks like before this change in observer:

![Screen Shot 2022-08-21 01-13-21](https://user-images.githubusercontent.com/9973/185815166-af734ad9-c18c-49b0-be4b-a03579b8c5c4.png)

And this is what it looks like after:
![Screen Shot 2022-08-21 01-10-32](https://user-images.githubusercontent.com/9973/185815193-5229cce7-ba38-4937-932a-9de214594197.png)

This changes the number of processes by around 120 which makes the observer applications tab much easier to use because you can see all the non-phoenix processes that you have much easier without as much scrolling.